### PR TITLE
カテゴリリストの余白を修正

### DIFF
--- a/src/sass/object/component/_c-category-list.scss
+++ b/src/sass/object/component/_c-category-list.scss
@@ -3,7 +3,7 @@
 .c-category-list__items {
   display: flex;
   flex-wrap: wrap;
-  margin: rem(-16) 0 0 rem(-24);
+  margin: rem(-16) 0 0 rem(-26);
   
   @include mq(md) {
     margin: initial;


### PR DESCRIPTION
デザインカンプに合わせてリスト左側の余白を修正