### PR TITLE
SP時の最大幅を追加

### DIFF
--- a/src/sass/object/project/_p-work-card.scss
+++ b/src/sass/object/project/_p-work-card.scss
@@ -18,7 +18,7 @@
   overflow: hidden;
   padding-top: 66.57%; // 223/335*100%
   position: relative;
-  // max-width: rem(540);
+  max-width: rem(500);
   margin-left: calc(50% - 50vw); // インナー幅を超えて表示
   margin-right: calc(50% - 50vw); // インナー幅を超えて表示
   transform: translate(calc(50vw - 50%)); // 中央揃え


### PR DESCRIPTION
max-widthを追加
※一覧ページと同じパーツを使いまわしているため、
　一覧ページはインナー幅まで表示する形で対応（カンプとは一致）