### PR TITLE
制作実績詳細ページのインナー幅を修正

### DIFF
--- a/src/ejs/project/_p-single-work-details.ejs
+++ b/src/ejs/project/_p-single-work-details.ejs
@@ -4,7 +4,7 @@
   {title:"その他", text:"テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。テキストが入ります。" }
 ] %>
 
-<ul class="p-single-work-details l-inner">
+<ul class="p-single-work-details">
   <% for (var point of pointItem) {%>
     <%- include('../project/_p-single-work-detail',{point:point.title, text:point.text}) %>
   <% } %>

--- a/src/sass/object/project/_p-single-work.scss
+++ b/src/sass/object/project/_p-single-work.scss
@@ -5,9 +5,15 @@
 }
 
 .p-single-work__inner {
-	max-width: rem(800);
+	max-width: rem(540);
 	width: 100%;
 	margin: 0 auto;
+	padding-right: $padding-sp;
+	padding-left: $padding-sp;
+	@include mq(md) {
+		padding-right: $padding-pc;
+		padding-left: $padding-pc;
+	}
 }
 
 .p-single-work__textbox {

--- a/src/sass/object/project/_p-work-card.scss
+++ b/src/sass/object/project/_p-work-card.scss
@@ -18,7 +18,7 @@
   overflow: hidden;
   padding-top: 66.57%; // 223/335*100%
   position: relative;
-  // max-width: rem(540);
+  max-width: rem(500);
   margin-left: calc(50% - 50vw); // インナー幅を超えて表示
   margin-right: calc(50% - 50vw); // インナー幅を超えて表示
   transform: translate(calc(50vw - 50%)); // 中央揃え


### PR DESCRIPTION
paddingを左右に追加
最大幅をパンくずと同じになるよう調整