### PR TITLE
制作実績ページのインナー幅を修正

### DIFF
--- a/src/ejs/project/_p-related-blog-card.ejs
+++ b/src/ejs/project/_p-related-blog-card.ejs
@@ -1,15 +1,13 @@
-<div class="p-related-blog-card">
-  <a href="#" class="p-related-blog-card__link">
-    <div class="p-related-blog-card__img">
-      <img src="<%= src %>" alt="<%= alt %>" />
-    </div>
-    <div class="p-related-blog-card__textbox">
-      <h3 class="p-related-blog-card__title"><%= title %></h3>
-      <p class="p-related-blog-card__text"><%= text %></p>
-    </div>
-    <div class="p-related-blog-card__meta">
-      <span class="p-related-blog-card__category"><%= category %></span>
-      <time class="p-related-blog-card__time" datetime="2021-07-20"><%= time %></time>
-    </div>
-    </a>
-</div>
+<a href="#" class="p-related-blog-card">
+  <div class="p-related-blog-card__img">
+    <img src="<%= src %>" alt="<%= alt %>" />
+  </div>
+  <div class="p-related-blog-card__textbox">
+    <h3 class="p-related-blog-card__title"><%= title %></h3>
+    <p class="p-related-blog-card__text"><%= text %></p>
+  </div>
+  <div class="p-related-blog-card__meta">
+    <span class="p-related-blog-card__category"><%= category %></span>
+    <time class="p-related-blog-card__time" datetime="2021-07-20"><%= time %></time>
+  </div>
+</a>

--- a/src/sass/object/project/_p-related-blog-card.scss
+++ b/src/sass/object/project/_p-related-blog-card.scss
@@ -1,6 +1,7 @@
 @use "global" as *;
 
 .p-related-blog-card {
+	display: block;
 	max-width: rem(600);
 	width: 100%;
 	margin: 0 auto;
@@ -9,6 +10,7 @@
 	@include mq('md') {
 		max-width: rem(251);
 		display: flex;
+		flex-direction: column;
 	}
 }
 
@@ -16,17 +18,11 @@
 	@include mq('md') {
 		background-color: $gray;
 		opacity: 1;
+		
 		.p-related-blog-card__textbox,
 		.p-related-blog-card__time {
 			color: $white;
 		}
-	}
-}
-
-.p-related-blog-card__link {
-	@include mq('md') {
-		display: flex;
-		flex-direction: column;
 	}
 }
 

--- a/src/sass/object/project/_p-single-work.scss
+++ b/src/sass/object/project/_p-single-work.scss
@@ -11,7 +11,7 @@
 	padding-right: $padding-sp;
 	padding-left: $padding-sp;
 	@include mq(md) {
-		max-width: rem(800);
+		max-width: rem(850);
 		padding-right: $padding-pc;
 		padding-left: $padding-pc;
 	}


### PR DESCRIPTION
制作ポイント等のアイテム幅が横幅100%になっていない（右側に余白がある）ため修正