### PR TITLE
関連制作カードのパーツを新規作成

### DIFF
--- a/src/ejs/project/_p-related-blog-card.ejs
+++ b/src/ejs/project/_p-related-blog-card.ejs
@@ -1,15 +1,13 @@
-<div class="p-related-blog-card">
-  <a href="#" class="p-related-blog-card__link">
-    <div class="p-related-blog-card__img">
-      <img src="<%= src %>" alt="<%= alt %>" />
-    </div>
-    <div class="p-related-blog-card__textbox">
-      <h3 class="p-related-blog-card__title"><%= title %></h3>
-      <p class="p-related-blog-card__text"><%= text %></p>
-    </div>
-    <div class="p-related-blog-card__meta">
-      <span class="p-related-blog-card__category"><%= category %></span>
-      <time class="p-related-blog-card__time" datetime="2021-07-20"><%= time %></time>
-    </div>
-    </a>
-</div>
+<a href="#" class="p-related-blog-card">
+  <div class="p-related-blog-card__img">
+    <img src="<%= src %>" alt="<%= alt %>" />
+  </div>
+  <div class="p-related-blog-card__textbox">
+    <h3 class="p-related-blog-card__title"><%= title %></h3>
+    <p class="p-related-blog-card__text"><%= text %></p>
+  </div>
+  <div class="p-related-blog-card__meta">
+    <span class="p-related-blog-card__category"><%= category %></span>
+    <time class="p-related-blog-card__time" datetime="2021-07-20"><%= time %></time>
+  </div>
+</a>

--- a/src/ejs/project/_p-related-work-card.ejs
+++ b/src/ejs/project/_p-related-work-card.ejs
@@ -1,0 +1,9 @@
+<div class="p-related-work-card">
+  <a href="single-work.html" class="p-related-work-card__link">
+    <div class="p-related-work-card__head">
+      <img src="<%= src %>" alt="<%= alt %>">
+      <span class="p-related-work-card__category"><%= category %></span>
+    </div>
+    <h2 class="p-related-work-card__title"><%= title %></h2>
+  </a>
+</div>

--- a/src/ejs/project/_p-related-work-cards.ejs
+++ b/src/ejs/project/_p-related-work-cards.ejs
@@ -13,7 +13,7 @@
     <ul class="p-related-work-cards__items">
       <% for (var item of cardItem) {%>
         <li class="p-related-work-cards__item">
-          <%- include('./_p-work-card',{src:item.src, alt:item.alt, title:item.title, excerpt:item.excerpt, category:item.category, datetime:item.datetime, time:item.time}) %>
+          <%- include('./_p-related-work-card',{src:item.src, alt:item.alt, title:item.title, excerpt:item.excerpt, category:item.category, datetime:item.datetime, time:item.time}) %>
         </li>
       <% } %>
     </ul>

--- a/src/sass/object/project/_p-related-blog-card.scss
+++ b/src/sass/object/project/_p-related-blog-card.scss
@@ -1,6 +1,7 @@
 @use "global" as *;
 
 .p-related-blog-card {
+	display: block;
 	max-width: rem(600);
 	width: 100%;
 	margin: 0 auto;
@@ -9,6 +10,7 @@
 	@include mq('md') {
 		max-width: rem(251);
 		display: flex;
+		flex-direction: column;
 	}
 }
 
@@ -16,17 +18,11 @@
 	@include mq('md') {
 		background-color: $gray;
 		opacity: 1;
+		
 		.p-related-blog-card__textbox,
 		.p-related-blog-card__time {
 			color: $white;
 		}
-	}
-}
-
-.p-related-blog-card__link {
-	@include mq('md') {
-		display: flex;
-		flex-direction: column;
 	}
 }
 

--- a/src/sass/object/project/_p-related-work-card.scss
+++ b/src/sass/object/project/_p-related-work-card.scss
@@ -1,0 +1,60 @@
+@use "global" as *;
+
+.p-related-work-card__link {
+  @include mq('md') {
+    &:hover {
+      .p-work-card__head img {
+        transform: scale(1.1);
+      }
+  
+      .p-work-card__title {
+        color: $yellow;
+      }
+    }
+  }
+}
+
+.p-related-work-card__head {
+  overflow: hidden;
+  padding-top: 66.57%; // 223/335*100%
+  position: relative;
+  max-width: rem(500);
+  
+  @include mq(md) {
+    max-width: initial;
+  }
+}
+
+.p-related-work-card__category {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  font-size: rem(16);
+  line-height: calc(23/16);
+  letter-spacing: 0.125em;
+  background-color: $black;
+  color: $white;
+  padding: rem(8) rem(20);
+}
+
+.p-related-work-card__head img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  transition: transform 0.3s;
+}
+
+.p-related-work-card__title {
+  font-weight: $medium;
+  font-size: rem(18);
+  line-height: calc(35/18);
+  letter-spacing: 0.056em;
+  color: $white;
+  text-align: center;
+  transition: color 0.3s;
+}

--- a/src/sass/object/project/_p-single-work.scss
+++ b/src/sass/object/project/_p-single-work.scss
@@ -11,7 +11,7 @@
 	padding-right: $padding-sp;
 	padding-left: $padding-sp;
 	@include mq(md) {
-		max-width: rem(800);
+		max-width: rem(850);
 		padding-right: $padding-pc;
 		padding-left: $padding-pc;
 	}


### PR DESCRIPTION
以下の理由から、制作カードは一覧ページと下層ページで使い回さず、下層ページの関連制作カードを新規作成
※一覧ページの制作カードは最大幅まで付いている⇔詳細ページの関連制作カードは最大幅まで付いていない
